### PR TITLE
fix: release reader

### DIFF
--- a/android/src/main/java/nl/volst/HoneywellScanner/HoneywellScannerModule.java
+++ b/android/src/main/java/nl/volst/HoneywellScanner/HoneywellScannerModule.java
@@ -123,6 +123,7 @@ public class HoneywellScannerModule extends ReactContextBaseJavaModule implement
     @ReactMethod
     public void stopReader(Promise promise) {
         if (reader != null) {
+            reader.release();
             reader.close();
         }
         if (manager != null) {


### PR DESCRIPTION
**Problem:**
- The barcode reader hardware is not released when we call to stopReader from the react code.
- This causes issues when WMS App and External App both are installed on one device and Once the user starts using the External App, the device in general stops opening external links in a browser that is used to login for WMS App.

**Solution:**
- This will release the reader before closing the connection, so the reader can be reused by the device.