### PR TITLE
android: use host project SDK versions and add namespace for AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,11 +12,13 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    namespace "nl.volst.HoneywellScanner"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
## Summary
Folds in the AGP 8 compatibility patch that consumers of this fork were applying via `patch-package`. After this PR is merged and the consumer's pin is updated, the patch file can be deleted entirely.

## Changes to `android/build.gradle`
- Replace hardcoded `compileSdkVersion 33`, `minSdkVersion 16`, and `targetSdkVersion 28` with `rootProject.ext.compileSdkVersion` / `minSdkVersion` / `targetSdkVersion` so the library inherits the consuming app's SDK versions.
- Add `namespace "nl.volst.HoneywellScanner"` which Android Gradle Plugin 8+ requires for library modules.

## Background
`team-lms-field-app` was pinning this fork at `f54e6b08` and then applying `patches/react-native-honeywell-scanner+1.0.1.patch` on top. The patch stopped applying after `compileSdkVersion` was bumped from 28 to 33 in the fork (context line mismatch), which is what motivated landing it upstream here.

## Test plan
- [ ] Build a consumer app on AGP 8 using this commit and confirm the module compiles without the namespace error
- [ ] Verify scanner functionality on a Honeywell device

🤖 Generated with [Claude Code](https://claude.com/claude-code)
